### PR TITLE
KAIZ 67 and 79 - Pod Endpoint and API Refinement (Meeting and Attendee)

### DIFF
--- a/server/api/meeting/[id].get.ts
+++ b/server/api/meeting/[id].get.ts
@@ -1,9 +1,14 @@
-import { fql } from 'fauna'
+import { AbortError, ServiceError, fql } from 'fauna'
 
 // Endpoint for reading meeting given an Id
 export default defineEventHandler(async (event) => {
 	// Get Meeting ID
 	const { id } = event.context.params as { id: string }
+
+	// Get the query parameters from the event object
+	const idType = event.req.url
+		? new URL(event.req.url, `http://${event.req.headers.host}`).searchParams.get('idType')
+		: 'meeting'
 
 	// Initialize Fauna client
 	const { client, error } = useFauna()
@@ -11,26 +16,28 @@ export default defineEventHandler(async (event) => {
 
 	try {
 		// Perform READ query
-		const query = fql`Meeting.byId(${id}){data}`
-		const document = await client.query(query)
+		const query = fql`let meeting = Meeting.byId(${id});
+		if (!meeting.exists()) abort({ message: "Meeting with this ID does not exist." });
+		meeting;`
 
-		// Return 'Not found' 404 if document is empty
-		if (document.data == null) {
-			return createError({
-				statusCode: 404,
-				statusMessage: 'Resource Not Found',
-			})
-		}
+		const response = await client.query(query)
 
 		// Return query result
-		return document.data
+		return response
 	} catch (error) {
-		console.log(error)
-
-		// Throw Server error for all other errors
-		return createError({
-			statusCode: 500,
-			statusMessage: 'Internal Error Occurred',
-		})
+		if (error instanceof AbortError) {
+			const abortError = error as AbortError
+			const abort = abortError.abort! as { message: string }
+			throw createError({
+				statusCode: abortError.httpStatus,
+				statusMessage: abort.message,
+			})
+		} else {
+			const serviceError = error as ServiceError
+			throw createError({
+				statusCode: serviceError.httpStatus,
+				statusMessage: serviceError.message,
+			})
+		}
 	}
 })

--- a/server/api/meeting/index.get.ts
+++ b/server/api/meeting/index.get.ts
@@ -1,31 +1,45 @@
-import { fql } from 'fauna'
+import { AbortError, ServiceError, fql } from 'fauna'
 
 // Endpoint for retrieving all meetings
 export default defineEventHandler(async (event) => {
 	// Initialize Fauna client
+	const { id } = event.context.params as { id: string }
+	const { cursor, count }: { cursor: string | undefined; count: string | undefined } = getQuery(event)
+
+	// Intitialize Fauna client
 	const { client, error } = useFauna()
 	if (error !== null) return error
 
 	try {
 		// Perform READ query
-		const query = fql`Meeting.all(){data}`
-		const document = await client.query(query)
+		let query = fql`Meeting.all(){data}`
 
-		// Return 'Not found' 404 if document is empty
-		if (!document.data) {
-			return createError({
-				statusCode: 404,
-				statusMessage: 'Resource Not Found',
-			})
+		if (cursor !== undefined && count !== undefined) {
+			query = fql`Set.paginate(${cursor}, ${Number(count)})`
+		} else if (cursor !== undefined) {
+			query = fql`Set.paginate(${cursor})`
+		} else if (count !== undefined) {
+			query = fql`Meeting.all().paginate(${Number(count)})`
 		}
 
-		// Return query result
-		return document.data
+		const response = await client.query(query)
+
+		// Return query response
+		return response
 	} catch (error) {
-		// Throw Server error for all other errors
-		return createError({
-			statusCode: 500,
-			statusMessage: 'Internal Error Occurred',
-		})
+		if (error instanceof AbortError) {
+			const abortError = error as AbortError
+			const abort = abortError.abort! as { message: string }
+			throw createError({
+				statusCode: abortError.httpStatus,
+				statusMessage: abort.message,
+			})
+		} else {
+			const serviceError = error as ServiceError
+			throw createError({
+				statusCode: serviceError.httpStatus,
+				statusMessage: serviceError.message,
+			})
+		}
 	}
 })

--- a/server/api/pod/[id].delete.ts
+++ b/server/api/pod/[id].delete.ts
@@ -1,32 +1,25 @@
 import { AbortError, ServiceError, fql } from 'fauna'
 
-// Endpoint for retrieving all meetings
+// Endpoint for deleting a pod given an Id
 export default defineEventHandler(async (event) => {
-	// Initialize Fauna client
+	// Get Pod ID
 	const { id } = event.context.params as { id: string }
-	const { cursor, count }: { cursor: string | undefined; count: string | undefined } = getQuery(event)
 
-	// Intitialize Fauna client
+	// Initialize Fauna client
 	const { client, error } = useFauna()
 	if (error !== null) return error
 
 	try {
-		// Perform READ query
-		let query = fql`{Meeting.all(){id, data}}`
-
-		if (cursor !== undefined && count !== undefined) {
-			query = fql`Set.paginate(${cursor}, ${Number(count)})`
-		} else if (cursor !== undefined) {
-			query = fql`Set.paginate(${cursor})`
-		} else if (count !== undefined) {
-			query = fql`{Meeting.all(){id, data}}.paginate(${Number(count)})`
-		}
+		// Perform READ query (print error if resource not found)
+		const query = fql`let pod = Pod.byId(${id});
+		if (!pod.exists()) abort({ message: "Pod with this ID does not exist." });
+		pod!.delete();`
 
 		const response = await client.query(query)
 
 		// Return query response
 		return response
-	} catch (error) {
+	} catch (error: unknown) {
 		if (error instanceof AbortError) {
 			const abortError = error as AbortError
 			const abort = abortError.abort! as { message: string }

--- a/server/api/pod/[id].patch.ts
+++ b/server/api/pod/[id].patch.ts
@@ -1,32 +1,32 @@
 import { AbortError, ServiceError, fql } from 'fauna'
 
-// Endpoint for retrieving all meetings
+// Endpoint for adding new meeting references for a pod
 export default defineEventHandler(async (event) => {
-	// Initialize Fauna client
+	// Get Pod ID
 	const { id } = event.context.params as { id: string }
-	const { cursor, count }: { cursor: string | undefined; count: string | undefined } = getQuery(event)
+	const body = await readBody(event)
 
-	// Intitialize Fauna client
+	// Initialize Fauna client
 	const { client, error } = useFauna()
 	if (error !== null) return error
 
 	try {
-		// Perform READ query
-		let query = fql`{Meeting.all(){id, data}}`
-
-		if (cursor !== undefined && count !== undefined) {
-			query = fql`Set.paginate(${cursor}, ${Number(count)})`
-		} else if (cursor !== undefined) {
-			query = fql`Set.paginate(${cursor})`
-		} else if (count !== undefined) {
-			query = fql`{Meeting.all(){id, data}}.paginate(${Number(count)})`
-		}
-
+		const query = fql`
+        let pod = Pod.byId(${id});
+        if (!pod.exists()) abort({ message: "Pod with this ID does not exist." });
+        
+        let meetingsList = pod!.meetings
+        let updatedList = if (meetingsList != Null){
+            meetingsList.append({Meeting.byId(${body.meetingId})})
+        } else{
+            [Meeting.byId(${body.meetingId})]
+        }
+        pod!.update({meetings: updatedList})
+    `
 		const response = await client.query(query)
 
-		// Return query response
 		return response
-	} catch (error) {
+	} catch (error: unknown) {
 		if (error instanceof AbortError) {
 			const abortError = error as AbortError
 			const abort = abortError.abort! as { message: string }

--- a/server/api/pod/index.get.ts
+++ b/server/api/pod/index.get.ts
@@ -1,32 +1,28 @@
 import { AbortError, ServiceError, fql } from 'fauna'
 
-// Endpoint for retrieving all meetings
+// endpoint for retreiving all pods
 export default defineEventHandler(async (event) => {
-	// Initialize Fauna client
-	const { id } = event.context.params as { id: string }
 	const { cursor, count }: { cursor: string | undefined; count: string | undefined } = getQuery(event)
 
-	// Intitialize Fauna client
+	// Initialize Fauna client
 	const { client, error } = useFauna()
 	if (error !== null) return error
 
 	try {
-		// Perform READ query
-		let query = fql`{Meeting.all(){id, data}}`
+		let query = fql`{Pod.all(){id, PodInfo: .data}}.paginate()`
 
 		if (cursor !== undefined && count !== undefined) {
 			query = fql`Set.paginate(${cursor}, ${Number(count)})`
 		} else if (cursor !== undefined) {
 			query = fql`Set.paginate(${cursor})`
 		} else if (count !== undefined) {
-			query = fql`{Meeting.all(){id, data}}.paginate(${Number(count)})`
+			query = fql`{Pod.all(){id, PodInfo: .data}}.paginate(${Number(count)})`
 		}
 
 		const response = await client.query(query)
 
-		// Return query response
 		return response
-	} catch (error) {
+	} catch (error: unknown) {
 		if (error instanceof AbortError) {
 			const abortError = error as AbortError
 			const abort = abortError.abort! as { message: string }

--- a/server/api/pod/index.post.ts
+++ b/server/api/pod/index.post.ts
@@ -1,0 +1,65 @@
+import { AbortError, ServiceError, fql } from 'fauna'
+
+// Body interface (read from POST request)
+interface Body {
+	name: string
+	leader: string
+	meetingTime: string
+	members: string[]
+	meetings: string[]
+}
+
+// Endpoint for creating a pod
+export default defineEventHandler(async (event) => {
+	// Initialize Fauna client
+	const { client, error } = useFauna()
+	if (error !== null) return error
+
+	// Read in request body (use type assertion to validate body)
+	const body = (await readBody(event)) as Body
+
+	// Store customerRef IDs
+	const members: string[] = body.members
+
+	// Initialize array to store the created attendeeRefs
+	let customers = []
+
+	// Create new meeting record and assign attendees
+	try {
+		// Store meeting info into seperate object
+		const Pod = {
+			name: body.name,
+			meetingTime: body.meetingTime,
+		}
+		// Perform POST query for meeting
+		const query = fql`Pod.create(${Pod})`
+		const podDoc = await client.query(query)
+
+		// Retrieve pod Id from query (used to update pod object with customer info)
+		const podId = podDoc.data?.id
+
+		// Query to update meeting to include attendee info
+		const updateQuery = fql`Pod.byId(${podId})!.update({leader: Customer.byId(${body.leader}), members: ${members}.map(Customer.byId), meetings: []})`
+		const updatedDoc = await client.query(updateQuery)
+
+		// Return the updated document (meeting + attendies)
+		return updatedDoc
+
+		// Catch error
+	} catch (error: unknown) {
+		if (error instanceof AbortError) {
+			const abortError = error as AbortError
+			const abort = abortError.abort! as { message: string }
+			throw createError({
+				statusCode: abortError.httpStatus,
+				statusMessage: abort.message,
+			})
+		} else {
+			const serviceError = error as ServiceError
+			throw createError({
+				statusCode: serviceError.httpStatus,
+				statusMessage: serviceError.message,
+			})
+		}
+	}
+})

--- a/server/api/pod/index.post.ts
+++ b/server/api/pod/index.post.ts
@@ -18,15 +18,12 @@ export default defineEventHandler(async (event) => {
 	// Read in request body (use type assertion to validate body)
 	const body = (await readBody(event)) as Body
 
-	// Store customerRef IDs
+	// Store customer IDs
 	const members: string[] = body.members
-
-	// Initialize array to store the created attendeeRefs
-	let customers = []
 
 	// Create new meeting record and assign attendees
 	try {
-		// Store meeting info into seperate object
+		// Store pod info into seperate object
 		const Pod = {
 			name: body.name,
 			meetingTime: body.meetingTime,
@@ -38,11 +35,11 @@ export default defineEventHandler(async (event) => {
 		// Retrieve pod Id from query (used to update pod object with customer info)
 		const podId = podDoc.data?.id
 
-		// Query to update meeting to include attendee info
+		// Query to update pod to include leader and member customerRefs
 		const updateQuery = fql`Pod.byId(${podId})!.update({leader: Customer.byId(${body.leader}), members: ${members}.map(Customer.byId), meetings: []})`
 		const updatedDoc = await client.query(updateQuery)
 
-		// Return the updated document (meeting + attendies)
+		// Return the updated document
 		return updatedDoc
 
 		// Catch error


### PR DESCRIPTION
**Pod endpoints added ~ KAIZ-67:**
1. GET by ID (returns a pod given an id)
2. GET all (returns all pods stored in the database)
3. DELETE (deletes the given pod)
4. POST (creates a new pod)
5. Patch (adds a new meeting reference to pod)

**API Refinement ~ KAIZ-79**
- All endpoints for meetings and pods were revised to follow new API conventions.

**Additional features:**
- Error handling (400, 404, 500 Error codes thrown where appropriate)
- Postman collection for testing pod endpoints created