### PR TITLE
Kaiz 98 - Revised GET by Id and ALL endpoints for Customers, Pods, Meetings, and Attendees

### DIFF
--- a/frontend/server/api/attendee/index.get.ts
+++ b/frontend/server/api/attendee/index.get.ts
@@ -1,31 +1,70 @@
-import { fql } from 'fauna'
+import { AbortError, ServiceError, fql } from 'fauna'
 
 // Endpoint for retrieving all attendees
 export default defineEventHandler(async (event) => {
+	const { cursor, count }: { cursor: string | undefined; count: string | undefined } = getQuery(event)
+
 	// Initialize Fauna client
 	const { client, error } = useFauna()
 	if (error !== null) return error
 
 	try {
-		// Perform READ query
-		const query = fql`Attendee.all(){data}`
-		const document = await client.query(query)
+		// Extract query params for external Refs (may not exist, so default to undefined)
+		const customerRef = event.req.url
+			? new URL(event.req.url, `http://${event.req.headers.host}`).searchParams.get('customerRef')
+			: undefined
+		const meetingRef = event.req.url
+			? new URL(event.req.url, `http://${event.req.headers.host}`).searchParams.get('meetingRef')
+			: undefined
 
-		// Return 'Not found' 404 if document is empty
-		if (!document.data) {
-			return createError({
-				statusCode: 404,
-				statusMessage: 'Resource Not Found',
-			})
+		// Default query
+		let query = fql`Attendee.all().paginate()`
+		const document = await client.query(query)
+		return document.data
+
+		// Check to see if client is making a paginated request
+		if (cursor !== undefined && count !== undefined) {
+			query = fql`Set.paginate(${cursor}, ${Number(count)})`
+		} else if (cursor !== undefined) {
+			query = fql`Set.paginate(${cursor})`
+		} else if (customerRef !== undefined || meetingRef !== undefined) {
+			// Apply query param as filter
+			const filterFied = customerRef !== undefined ? 'customerRef' : 'meetingRef'
+			const filterValue = customerRef !== undefined ? customerRef : meetingRef
+			const filterObject =
+				customerRef !== undefined ? fql`Customer.byId(${filterValue})` : fql`Meeting.byId(${filterValue})`
+
+			const filterClause = fql`.${filterFied} == ${filterObject}`
+
+			query =
+				count !== undefined
+					? fql`let filteredAttendees = ${filterObject};
+				Attendee.where(${filterClause}).paginate(${Number(count)})`
+					: fql`let filteredAttendees = ${filterObject};
+				Attendee.where(${filterClause}).paginate()`
+		} else {
+			query = count !== undefined ? fql`Attendee.all().paginate(${Number(count)})` : fql`Attendee.all().paginate()`
 		}
 
+		// Perform query and store doc
+		//const document = await client.query(query)
+
 		// Return query result
-		return document.data
-	} catch (error) {
-		// Throw Server error for all other errors
-		return createError({
-			statusCode: 500,
-			statusMessage: 'Internal Error Occurred',
-		})
+		//return document.data
+	} catch (error: unknown) {
+		if (error instanceof AbortError) {
+			const abortError = error as AbortError
+			const abort = abortError.abort! as { message: string }
+			throw createError({
+				statusCode: abortError.httpStatus,
+				statusMessage: abort.message,
+			})
+		} else {
+			const serviceError = error as ServiceError
+			throw createError({
+				statusCode: serviceError.httpStatus,
+				statusMessage: serviceError.message,
+			})
+		}
 	}
 })

--- a/frontend/server/api/customer/[id].get.ts
+++ b/frontend/server/api/customer/[id].get.ts
@@ -9,11 +9,11 @@ export default defineEventHandler(async (event) => {
 	if (error !== null) return error
 
 	try {
-		const query = fql`
-    let customer = Customer.byId(${id});
-    if (!customer.exists()) abort({ message: "Customer with this ID does not exist." });
-    customer;
-    `
+		const query = fql`let customer = Customer.byId(${id}); 
+		if (!customer.exists()) 
+		abort({ message: "Customer with this ID does not exist." });
+		customer;
+		`
 		const response = await client.query(query)
 
 		return response

--- a/frontend/server/api/customer/index.get.ts
+++ b/frontend/server/api/customer/index.get.ts
@@ -1,8 +1,6 @@
 import { AbortError, ServiceError, fql } from 'fauna'
 
 export default defineEventHandler(async (event) => {
-	// Get Customer ID
-	const { id } = event.context.params as { id: string }
 	const { cursor, count }: { cursor: string | undefined; count: string | undefined } = getQuery(event)
 
 	// Initialize Fauna client
@@ -10,14 +8,27 @@ export default defineEventHandler(async (event) => {
 	if (error !== null) return error
 
 	try {
+		// Extract query params for external Refs (may not exist, so default to undefined)
+		const podRef = event.req.url
+			? new URL(event.req.url, `http://${event.req.headers.host}`).searchParams.get('podRef')
+			: undefined
+
+		// Default query
 		let query = fql`Customer.all().paginate()`
 
+		// Check to see if client is making a paginated request
 		if (cursor !== undefined && count !== undefined) {
 			query = fql`Set.paginate(${cursor}, ${Number(count)})`
 		} else if (cursor !== undefined) {
 			query = fql`Set.paginate(${cursor})`
 		} else if (count !== undefined) {
-			query = fql`Customer.all().paginate(${Number(count)})`
+			// Apply additional filter if podRef exists, otherwise paginate without
+			query = podRef
+				? fql`let pod = Pod.byId(${podRef}); Customer.where(.podRef == pod).paginate(${Number(count)});`
+				: fql`Customer.all().paginate(${Number(count)})`
+		} else if (podRef !== undefined) {
+			query = fql`let pod = Pod.byId(${podRef})
+			Customer.where(.podRef == pod).paginate()`
 		}
 
 		const response = await client.query(query)

--- a/frontend/server/api/meeting/index.get.ts
+++ b/frontend/server/api/meeting/index.get.ts
@@ -2,38 +2,34 @@ import { AbortError, ServiceError, fql } from 'fauna'
 
 // Endpoint for retrieving all meetings
 export default defineEventHandler(async (event) => {
-	// Initialize Fauna client
-	const { cursor, count }: { cursor: string | undefined; count: string | undefined } = getQuery(event)
+	// Extract params from request query
+	const { cursor, count, podRef }: { cursor: string; count: string; podRef: string } = getQuery(event)
 
 	// Intitialize Fauna client
 	const { client, error } = useFauna()
 	if (error !== null) return error
 
 	try {
-		// Extract query params for external Refs (may not exist, so default to undefined)
-		const podRef = event.req.url
-			? new URL(event.req.url, `http://${event.req.headers.host}`).searchParams.get('podRef')
-			: undefined
-
 		// Default Query
 		let query = fql`Meeting.all().paginate()`
 
+		// Check to see if client is making a paginated request
 		if (cursor !== undefined && count !== undefined) {
 			query = fql`Set.paginate(${cursor}, ${Number(count)})`
 		} else if (cursor !== undefined) {
 			query = fql`Set.paginate(${cursor})`
-		} else if (count !== undefined) {
-			// Apply additional filter if PodRef exists, otherwise paginate without
-			query = podRef
-				? fql`let pod = Pod.byId(${podRef}); Meeting.where(.podRef == pod).paginate(${Number(count)});`
-				: fql`Meeting.all().paginate(${Number(count)})`
 		} else if (podRef !== undefined) {
-			query = fql`let pod = Pod.byId(${podRef}); Meeting.where(.podRef == pod).paginate()`
+			// Check if count parameter is passed for pagination
+			if (count !== undefined) {
+				query = fql`let pod = Pod.byId(${podRef}); Meeting.where(.podRef == pod).paginate(${Number(count)})`
+			} else {
+				query = fql`let pod = Pod.byId(${podRef}); Meeting.where(.podRef == pod).paginate()`
+			}
+		} else if (count !== undefined) {
+			query = fql`Meeting.all().paginate(${Number(count)})`
 		}
 
 		const response = await client.query(query)
-
-		// Return query response
 		return response
 	} catch (error) {
 		if (error instanceof AbortError) {

--- a/frontend/server/api/pod/[id].get.ts
+++ b/frontend/server/api/pod/[id].get.ts
@@ -2,7 +2,7 @@ import { AbortError, ServiceError, fql } from 'fauna'
 
 // Endpoint for reading pod given an Id
 export default defineEventHandler(async (event) => {
-	// Get pod ID
+	// Extract id param from request query
 	const { id } = event.context.params as { id: string }
 
 	// Initialize Fauna client
@@ -13,11 +13,9 @@ export default defineEventHandler(async (event) => {
 		// Perform READ query
 		const query = fql`let pod = Pod.byId(${id});
 		if (!pod.exists()) abort({ message: "Pod with this ID does not exist." });
-		pod{PodInfo: .data};`
+		pod;`
 
 		const response = await client.query(query)
-
-		// Return query result
 		return response
 	} catch (error) {
 		if (error instanceof AbortError) {

--- a/frontend/server/api/pod/index.get.ts
+++ b/frontend/server/api/pod/index.get.ts
@@ -2,6 +2,7 @@ import { AbortError, ServiceError, fql } from 'fauna'
 
 // endpoint for retreiving all pods
 export default defineEventHandler(async (event) => {
+	// Extract params from request query
 	const { cursor, count }: { cursor: string | undefined; count: string | undefined } = getQuery(event)
 
 	// Initialize Fauna client
@@ -9,18 +10,19 @@ export default defineEventHandler(async (event) => {
 	if (error !== null) return error
 
 	try {
-		let query = fql`{Pod.all(){id, PodInfo: .data}}.paginate()`
+		// Default query
+		let query = fql`Pod.all().paginate()`
 
+		// Check to see if client is making a paginated request
 		if (cursor !== undefined && count !== undefined) {
 			query = fql`Set.paginate(${cursor}, ${Number(count)})`
 		} else if (cursor !== undefined) {
 			query = fql`Set.paginate(${cursor})`
 		} else if (count !== undefined) {
-			query = fql`{Pod.all(){id, PodInfo: .data}}.paginate(${Number(count)})`
+			query = fql`Pod.all().paginate(${Number(count)})`
 		}
 
 		const response = await client.query(query)
-
 		return response
 	} catch (error: unknown) {
 		if (error instanceof AbortError) {


### PR DESCRIPTION
Work completed/Features added:

- Updated schemas and sample data for Customers, Pods, Meetings, and Attendees within FauanaDB
- Adding searching by Ref ids to Customers, Pods, Meetings, and Attendees via /index.get.ts
- updated respective /[].get.ts to follow current query flow
- Postman collection has been updated to include sample query params to test new endpoint functionality