### PR TITLE
KAIZ-126

### DIFF
--- a/composables/useApi.ts
+++ b/composables/useApi.ts
@@ -3,6 +3,7 @@ import type {
 	AttendeeFields,
 	Customer,
 	CustomerFields,
+	HmsEventsResponse,
 	HmsRoom,
 	HmsSession,
 	Meeting,
@@ -17,6 +18,14 @@ import type {
 type MeetingQueryParams =
 	| { podId?: never; count?: number; cursor?: string }
 	| { podId: Numberic; count?: number; cursor?: never }
+
+type EventsFilters = {
+	session_id?: string
+	peer_id?: string
+	user_id?: string
+	limit?: number
+	start?: string
+}
 
 export const useApi = () => {
 	const createCustomer = async (customer: CustomerFields) => {
@@ -197,6 +206,31 @@ export const useApi = () => {
 		return session
 	}
 
+	const getHmsEvents = async (
+		roomId: string,
+		eventType: 'add' | 'update' | 'remove',
+		filters?: EventsFilters,
+	): Promise<HmsEventsResponse> => {
+		const managementToken = await generateManagementToken()
+
+		const queryParams = {
+			room_id: roomId,
+			type: `track.${eventType}.success`,
+			...filters,
+		}
+
+		const events = await $fetch<HmsEventsResponse>(`https://api.100ms.live/v2/analytics/events`, {
+			method: 'GET',
+			headers: {
+				Authorization: `Bearer ${managementToken}`,
+				'Content-Type': 'application/json',
+			},
+			query: queryParams,
+		})
+
+		return events
+	}
+
 	return {
 		// Customer
 		createCustomer,
@@ -223,5 +257,10 @@ export const useApi = () => {
 		getAttendee,
 		updateAttendee,
 		deleteAttendee,
+
+		// HMS
+		getHmsRoom,
+		getHmsSession,
+		getHmsEvents,
 	}
 }

--- a/composables/useApi.ts
+++ b/composables/useApi.ts
@@ -3,6 +3,8 @@ import type {
 	AttendeeFields,
 	Customer,
 	CustomerFields,
+	HmsRoom,
+	HmsSession,
 	Meeting,
 	MeetingFields,
 	Numberic,
@@ -165,6 +167,34 @@ export const useApi = () => {
 		const response = await $fetch(`/api/attendee/${id}`, { method: 'DELETE' })
 
 		return response
+	}
+
+	const getHmsRoom = async (roomId: string): Promise<HmsRoom> => {
+		const managementToken = await generateManagementToken()
+
+		const room = await $fetch<HmsRoom>(`https://api.100ms.live/v2/active-rooms/${roomId}`, {
+			method: 'GET',
+			headers: {
+				Authorization: `Bearer ${managementToken}`,
+				'Content-Type': 'application/json',
+			},
+		})
+
+		return room
+	}
+
+	const getHmsSession = async (sessionId: string): Promise<HmsSession> => {
+		const managementToken = await generateManagementToken()
+
+		const session = await $fetch<HmsSession>(`https://api.100ms.live/v2/sessions/${sessionId}`, {
+			method: 'GET',
+			headers: {
+				Authorization: `Bearer ${managementToken}`,
+				'Content-Type': 'application/json',
+			},
+		})
+
+		return session
 	}
 
 	return {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -116,3 +116,40 @@ export interface RoomCodeResponse {
 		enabled: boolean
 	}>
 }
+
+interface HmsRoomSession {
+	id: string
+	created_at: string
+	peers: string[]
+}
+
+export interface HmsRoom {
+	id: string
+	name: string
+	customer_id: string
+	session: Session
+}
+
+interface Peer {
+	id: string
+	session_id: string
+	name: string
+	role: string
+	user_id: string
+	joined_at: string
+	left_at: string
+}
+
+interface Peers {
+	[key: string]: Peer
+}
+
+export interface HmsSession {
+	id: string
+	room_id: string
+	customer_id: string
+	active: boolean
+	peers: Peers
+	created_at: string
+	updated_at: string
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -153,3 +153,36 @@ export interface HmsSession {
 	created_at: string
 	updated_at: string
 }
+
+interface HmsTrackEvents {
+	room_id: string
+	session_id: string
+	room_name: string
+	peer_id: string
+	user_id: string
+	user_name: string
+	joined_at: string
+	role: string
+	track_id: string
+	stream_id: string
+	type: string
+	source: string
+	mute: boolean
+	started_at: string
+	stopped_at?: string // only specified in track.remove.success event
+}
+
+export interface HmsEvents {
+	version: string
+	id: string
+	timestamp: string
+	type: string
+	data: HmsTrackEvents
+}
+
+export interface HmsEventsResponse {
+	limit: number
+	total: number
+	next: string
+	events: HmsEvents[]
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -79,15 +79,21 @@ export interface AttendeeFields {
 }
 
 export interface HmsInstance {
-	userName: Ref<string>;
-	roomCode: Ref<string>;
-	videoRefs: Ref<Array<any>>; // Specify a more accurate type if available
-	isLocalAudioEnabled: Ref<boolean>;
-	isLocalVideoEnabled: Ref<boolean>;
-	isConnected: Ref<boolean>;
-	peers: Ref<Array<any>>; // Specify a more accurate type if available
-	joinRoom: (roomCode: string, username: string) => Promise<void>;
-	leaveRoom: () => Promise<void>;
-	toggleAudio: () => Promise<void>;
-	toggleVideo: () => Promise<void>;
-  }
+	userName: Ref<string>
+	roomCode: Ref<string>
+	videoRefs: Ref<Array<any>> // Specify a more accurate type if available
+	isLocalAudioEnabled: Ref<boolean>
+	isLocalVideoEnabled: Ref<boolean>
+	isConnected: Ref<boolean>
+	peers: Ref<Array<any>> // Specify a more accurate type if available
+	joinRoom: (roomCode: string, username: string) => Promise<void>
+	leaveRoom: () => Promise<void>
+	toggleAudio: () => Promise<void>
+	toggleVideo: () => Promise<void>
+	sendBroadcastMessage: (message: string) => Promise<void>
+	messages: Ref<Array<string>>
+}
+interface ChatMessage {
+	id: string
+	content: string
+}


### PR DESCRIPTION
This PR fulfills [KAIZ-126](https://teamkaizencsus.atlassian.net/browse/KAIZ-126), "Track Attendees through 100ms".

- Types for HMS response objects for room/session/events.
- API functions for retrieving a room/session/events by ID.

See here for usage:

- https://www.100ms.live/docs/server-side/v2/api-reference/active-rooms/retrieve-active-room
- https://www.100ms.live/docs/server-side/v2/api-reference/Sessions/retrieve-a-session
- https://www.100ms.live/docs/server-side/v2/api-reference/analytics/track-events
